### PR TITLE
Improved performance using numpy sorted union and intersect

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,5 +3,5 @@
   <component name="Black">
     <option name="sdkName" value="Python 3.11 virtualenv at ~/Documents/Coding/cubedpandas/.venv" />
   </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.11 virtualenv at ~/Documents/Coding/cubedpandas/.venv" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.9 (nanocube)" project-jdk-type="Python SDK" />
 </project>

--- a/.idea/nanocube.iml
+++ b/.idea/nanocube.iml
@@ -7,8 +7,9 @@
       <excludeFolder url="file://$MODULE_DIR$/build" />
       <excludeFolder url="file://$MODULE_DIR$/dist" />
       <excludeFolder url="file://$MODULE_DIR$/nanocube.egg-info" />
+      <excludeFolder url="file://$MODULE_DIR$/env" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.11 virtualenv at ~/Documents/Coding/cubedpandas/.venv" jdkType="Python SDK" />
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/nanocube/__init__.py
+++ b/nanocube/__init__.py
@@ -6,15 +6,6 @@ import pandas as pd
 from pandas.api.types import is_numeric_dtype, is_bool_dtype, is_float_dtype
 from pyroaring import BitMap
 
-__author__ = "Thomas Zeutschler"
-__version__ = "0.1.5"
-__license__ = "MIT"
-VERSION = __version__
-
-__all__ = [
-    "NanoCube",
-]
-
 
 class NanoCube:
     """
@@ -23,7 +14,7 @@ class NanoCube:
     used as dimensions and all numeric columns as measures. Roaring Bitmaps (https://roaringbitmap.org) are used
     to construct and query a multi-dimensional cube, Numpy is used for aggregations.
     """
-    def __init__(self, df: pd.DataFrame, dimensions: list | None = None, measures:list | None = None, caching: bool = True):
+    def __init__(self, df: pd.DataFrame, dimensions: 'list | None' = None, measures:'list | None' = None, caching: bool = True):
         """
         Initialize an in-memory OLAP cube for fast point queries upon a Pandas DataFrame.
         By default, all non-numeric columns will be used as dimensions and all numeric columns as measures if

--- a/nanocube/cube2.py
+++ b/nanocube/cube2.py
@@ -1,0 +1,80 @@
+from functools import reduce
+
+import numpy as np
+import pandas as pd
+from pandas.core.dtypes.common import is_numeric_dtype, is_bool_dtype, is_float_dtype
+import sortednp as snp
+from pyroaring import BitMap
+
+
+def start_stop_arr(a):
+    mask = np.concatenate(([True], a[1:] != a[:-1], [True]))
+    idx = np.flatnonzero(mask)
+    idx2 = np.concatenate((idx[:-1,None], (idx[1:,None]-1)),axis=1)
+    return idx2
+
+
+class Cube2:
+    def __init__(self, df: pd.DataFrame, measures = None, dimensions = None, caching=False):
+        # self.df = df.reset_index(drop=True)
+        self.df = df
+        self.index = {}
+
+        self.measures = [c for c in df.columns if is_numeric_dtype(df[c].dtype) and not is_bool_dtype(df[c].dtype)] if measures is None else measures
+        self.dimensions = [c for c in df.columns if not c in self.measures and not is_float_dtype(df[c].dtype)] if dimensions is None else dimensions
+
+        self.compute_index()
+
+    def compute_index(self):
+        self.index = {}
+
+        for col in self.dimensions:
+            col_index = {}
+
+            for i, val in enumerate(self.df[col].values):
+                if val not in col_index:
+                    col_index[val] = BitMap([i])
+                else:
+                    col_index[val].add(i)
+
+            for val in col_index:
+                col_index[val] = np.array(col_index[val].to_array())
+
+            self.index[col] = col_index
+
+    def get(self, *args, **kwargs):
+        matches = []
+
+        for col, value_or_values in kwargs.items():
+            col_index = self.index[col]
+
+            if isinstance(value_or_values, list):
+                multi_index = []
+                for v in value_or_values:
+                    multi_index.append(col_index[v])
+                col_matches_index = reduce(lambda x, y: snp.merge(x, y, duplicates=snp.MergeDuplicates.DROP), multi_index)
+            else:
+                col_matches_index = col_index[value_or_values]
+
+            matches.append(col_matches_index)
+
+        matches_sorted = sorted(matches, key=lambda l: len(l))
+
+        matches = reduce(lambda x, y: snp.intersect(x, y, duplicates=snp.IntersectDuplicates.DROP), matches_sorted)
+
+        result = []
+
+        if len(args) > 0:
+            result_cols = args
+        else:
+            result_cols = self.measures
+
+        for col in result_cols:
+            result.append(np.nansum(self.df[col].values[matches]).item())
+
+        if len(args) == 1:
+            return result[0]
+        elif len(args) == 0:
+            return dict(zip(result_cols, result))
+
+        return result

--- a/nanocube/cube2.py
+++ b/nanocube/cube2.py
@@ -7,74 +7,97 @@ import sortednp as snp
 from pyroaring import BitMap
 
 
-def start_stop_arr(a):
-    mask = np.concatenate(([True], a[1:] != a[:-1], [True]))
-    idx = np.flatnonzero(mask)
-    idx2 = np.concatenate((idx[:-1,None], (idx[1:,None]-1)),axis=1)
-    return idx2
-
-
 class Cube2:
-    def __init__(self, df: pd.DataFrame, measures = None, dimensions = None, caching=False):
-        # self.df = df.reset_index(drop=True)
-        self.df = df
-        self.index = {}
+    """
+    A super minimalistic (27 lines of code) in-memory OLAP cube implementation for lightning fast point queries
+    upon Pandas DataFrames (100x to 1000x times faster than Pandas). By default, all non-numeric columns will be
+    used as dimensions and all numeric columns as measures. Roaring Bitmaps (https://roaringbitmap.org) are used
+    to construct and query a multi-dimensional cube, Numpy is used for aggregations.
+    """
+    def __init__(self, df: pd.DataFrame, dimensions: 'list | None' = None, measures:'list | None' = None, caching: bool = True):
+        """
+        Initialize an in-memory OLAP cube for fast point queries upon a Pandas DataFrame.
+        By default, all non-numeric columns will be used as dimensions and all numeric columns as measures if
+        not specified otherwise. All column names need to be Python-keyword-compliant. Roaring Bitmaps
+        (https://roaringbitmap.org) are used to store and query records, Numpy is used for aggregations.
 
-        self.measures = [c for c in df.columns if is_numeric_dtype(df[c].dtype) and not is_bool_dtype(df[c].dtype)] if measures is None else measures
-        self.dimensions = [c for c in df.columns if not c in self.measures and not is_float_dtype(df[c].dtype)] if dimensions is None else dimensions
-
-        self.compute_index()
-
-    def compute_index(self):
-        self.index = {}
-
-        for col in self.dimensions:
-            col_index = {}
-
-            for i, val in enumerate(self.df[col].values):
-                if val not in col_index:
-                    col_index[val] = BitMap([i])
+        Parameters
+        ----------
+        df : pd.DataFrame
+            The DataFrame to be converted to a Cube.
+        dimensions : list | None
+            (optional) List of column names from the Pandas DataFrame to be used as dimensions.
+        measures : list | None
+            (optional) List of columns names from the Pandas DataFrame to be used as measures.
+        caching : bool
+            (optional) If True, the results of the queries will be cached for faster repetitive access.
+        Examples
+        --------
+        >>> import pandas as pd
+        >>> from nanocube import NanoCube
+        >>> # Create a DataFrame
+        >>> df = pd.DataFrame({'customer': [ 'A',  'B',  'A',  'B',  'A'],
+        >>>                    'product':  ['P1', 'P2', 'P3', 'P1', 'P2'],
+        >>>                    'promo':    [True, False, True, True, False],
+        >>>                    'sales':    [ 100,  200,  300,  400,  500],
+        >>>                    'cost':     [  60,   90,  120,  200,  240]})
+        >>> # Convert to a Cube
+        >>> cube = NanoCube(df)
+        >>> print(cube.get(customer='A', product='P1'))  # [100, 60]
+        >>> print(cube.get(customer='A'))                # [900, 420]
+        >>> print(cube.get(promo=True))                  # [800, 380]
+        >>> print(cube.get(promo=True))                  # [800, 380]
+        """
+        measures = [c for c in df.columns if is_numeric_dtype(df[c].dtype) and not is_bool_dtype(df[c].dtype)] if measures is None else measures
+        dimensions = [c for c in df.columns if not c in measures and not is_float_dtype(df[c].dtype)] if dimensions is None else dimensions
+        self.dimensions:dict = dict([(col, i) for i, col in enumerate(dimensions)])
+        self.measures:dict = dict([(col, i) for i, col in enumerate(measures)])
+        self.values: list = [df[c].values for c in self.measures.keys()]  # value vectors (references only)
+        self.cache: dict = {"@":0} if caching else None
+        self.bitmaps: list = []  # bitmaps per dimension per member containing the row ids of the DataFrame
+        for col in self.dimensions.keys():
+            member_bitmaps = {}
+            for row, member in enumerate(df[col].to_list()):
+                if member not in member_bitmaps:
+                    member_bitmaps[member] = BitMap([row])
                 else:
-                    col_index[val].add(i)
+                    member_bitmaps[member].add(row)
 
-            for val in col_index:
-                col_index[val] = np.array(col_index[val].to_array())
+            for v in member_bitmaps.keys():
+                member_bitmaps[v] = np.array(member_bitmaps[v].to_array())
 
-            self.index[col] = col_index
+            self.bitmaps.append(member_bitmaps)
 
     def get(self, *args, **kwargs):
-        matches = []
+        """
+        Get the aggregated values for the given dimensions and members.
 
-        for col, value_or_values in kwargs.items():
-            col_index = self.index[col]
+        :param kwargs: the dimension column names as keyword and their requested members as argument.
+        :param args: (optional) some measure column names to be returned.
+        :return:
+            The aggregated values as:
+            - a dict of (measures, value) pairs for all defined measures.
+            - a scalar if only one measure as arg is given.
+            - a list of values for multiple measures if multiple args are given.
+        """
+        if self.cache:
+            key = f"{args}-{kwargs}"
+            if key in self.cache:
+                return self.cache[key]
+        bitmaps = [(reduce(lambda x, y: snp.merge(x, y, duplicates=snp.MergeDuplicates.DROP), [self.bitmaps[d][m] for m in kwargs[dim]])
+                   if (isinstance(kwargs[dim], list) or isinstance(kwargs[dim], tuple)) and not isinstance(kwargs[dim], str)
+                   else self.bitmaps[d][kwargs[dim]]) for d, dim in enumerate(self.dimensions.keys()) if dim in kwargs]
 
-            if isinstance(value_or_values, list):
-                multi_index = []
-                for v in value_or_values:
-                    multi_index.append(col_index[v])
-                col_matches_index = reduce(lambda x, y: snp.merge(x, y, duplicates=snp.MergeDuplicates.DROP), multi_index)
-            else:
-                col_matches_index = col_index[value_or_values]
+        # sort from shortest to largest size to increase set intersection performance
+        bitmaps = sorted(bitmaps, key=lambda l: len(l))
 
-            matches.append(col_matches_index)
-
-        matches_sorted = sorted(matches, key=lambda l: len(l))
-
-        matches = reduce(lambda x, y: snp.intersect(x, y, duplicates=snp.IntersectDuplicates.DROP), matches_sorted)
-
-        result = []
-
-        if len(args) > 0:
-            result_cols = args
+        records = reduce(lambda x, y: snp.intersect(x, y, duplicates=snp.IntersectDuplicates.DROP), bitmaps) if bitmaps else False
+        if len(args) == 0: # return all totals as a dict
+            result = dict([(c, np.nansum(self.values[i][records]).item()) if len(records) else(c, np.nansum(self.values[i]).item()) for c, i in self.measures.items()])
+        elif len(args) == 1: # return total as scalar
+            result = np.nansum(self.values[self.measures[args[0]]][records] if len(records) else self.values[self.measures[args[0]]]).item()
         else:
-            result_cols = self.measures
-
-        for col in result_cols:
-            result.append(np.nansum(self.df[col].values[matches]).item())
-
-        if len(args) == 1:
-            return result[0]
-        elif len(args) == 0:
-            return dict(zip(result_cols, result))
-
+            result = [np.nansum(self.values[self.measures[a]][records] if len(records) else self.values[self.measures[a]]).item() for a in args] # return totals as a list
+        if self.cache:
+            self.cache[key] = result
         return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 numpy >= 1.24.0
 pandas
 pyroaring
+sortednp==0.5.0
 
 # for deployment
 build


### PR DESCRIPTION
Hi there, I was interested in your implementation and got curious if its performance could be improved by leveraging numpy arrays directly and doing sorted unions/intersects instead of relying on pyroaring's BitMaps.

Keeping initialisation overhead down to match the original implementation ended up being the most difficult, but I got pretty close. Init overhead comparison from the benchmark script can be found below:

```
...with 100 rows and 10 loops, cube init in 0.00081 sec, cube2 init in 0.00089 sec, overall in 0.02116 sec.
...with 200 rows and 10 loops, cube init in 0.00061 sec, cube2 init in 0.00124 sec, overall in 0.02050 sec.
...with 400 rows and 10 loops, cube init in 0.00118 sec, cube2 init in 0.00199 sec, overall in 0.02318 sec.
...with 800 rows and 10 loops, cube init in 0.00172 sec, cube2 init in 0.00344 sec, overall in 0.02799 sec.
...with 1,600 rows and 10 loops, cube init in 0.00290 sec, cube2 init in 0.00539 sec, overall in 0.03604 sec.
...with 3,200 rows and 10 loops, cube init in 0.00519 sec, cube2 init in 0.00886 sec, overall in 0.05205 sec.
...with 6,400 rows and 10 loops, cube init in 0.00907 sec, cube2 init in 0.01470 sec, overall in 0.08270 sec.
...with 12,800 rows and 10 loops, cube init in 0.01587 sec, cube2 init in 0.02405 sec, overall in 0.14035 sec.
...with 25,600 rows and 10 loops, cube init in 0.02788 sec, cube2 init in 0.03808 sec, overall in 0.24720 sec.
...with 51,200 rows and 10 loops, cube init in 0.05071 sec, cube2 init in 0.06107 sec, overall in 0.45752 sec.
...with 102,400 rows and 10 loops, cube init in 0.09740 sec, cube2 init in 0.10827 sec, overall in 0.86423 sec.
...with 204,800 rows and 10 loops, cube init in 0.18905 sec, cube2 init in 0.19851 sec, overall in 1.70267 sec.
...with 409,600 rows and 10 loops, cube init in 0.37383 sec, cube2 init in 0.38502 sec, overall in 3.37266 sec.
...with 819,200 rows and 10 loops, cube init in 0.75209 sec, cube2 init in 0.76295 sec, overall in 6.84906 sec.
...with 1,638,400 rows and 10 loops, cube init in 1.47288 sec, cube2 init in 1.49330 sec, overall in 13.50181 sec.
...with 3,276,800 rows and 10 loops, cube init in 2.93813 sec, cube2 init in 3.01520 sec, overall in 27.32047 sec.
...with 6,553,600 rows and 10 loops, cube init in 5.85592 sec, cube2 init in 5.94174 sec, overall in 54.03826 sec.
...with 13,107,200 rows and 10 loops, cube init in 11.72648 sec, cube2 init in 11.96820 sec, overall in 108.82562 sec.
```

And here are all the graphs produced by the benchmark script, the alternative implementation is marked as "Cube2"

![hk](https://github.com/user-attachments/assets/1f072479-a01d-4444-b5d2-0e7663f8690e)
![xl](https://github.com/user-attachments/assets/8ea8d0eb-1f1f-446c-9418-6ccd197bc39d)
![l](https://github.com/user-attachments/assets/616903ca-2c98-42e5-a4a4-a591eee42f64)
![m](https://github.com/user-attachments/assets/d33a7a48-2242-4976-afeb-8dd8d9946f32)
![s](https://github.com/user-attachments/assets/eb741a80-fa42-46c0-a95b-82825c224f44)

As you can see the XL performance now also consistently beats pandas on any dataframe size

This PR is not prepared to be merged as it still includes both implementations to allow anyone to run these comparisons, but rather serves as a side track which can be copied from if you would like to incorporate these performance improvements.